### PR TITLE
Use quay.io/eclipse/che-quarkus:next

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,7 +21,7 @@ components:
     attributes:
       tool: console-import
     container:
-      image: quay.io/eclipse/che-quarkus:nightly
+      image: quay.io/eclipse/che-quarkus:next
       memoryLimit: 1512Mi
       mountSources: true
       volumeMounts:


### PR DESCRIPTION
Use **quay.io/eclipse/che-quarkus:next** instead of obsolete **quay.io/eclipse/che-quarkus:nightly**.